### PR TITLE
Quick and dirty lng/lat input to make this work when location lookup fails.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,6 +5,7 @@ import Countdown from '~components/Countdown'
 import Disc from '~components/Disc'
 import Links from '~components/Links'
 import TimeTable from '~components/TimeTable'
+import LngLatInput from '~components/LngLatInput'
 import Waiting from '~components/Waiting'
 import { WIDTH } from '~singletons/constants'
 import { Space, State } from '~singletons/interfaces'
@@ -25,6 +26,7 @@ const App = ({ space }: Props): JSX.Element => {
       <Countdown />
       <Disc />
       <TimeTable />
+      <LngLatInput />
       <Links />
     </div>
   )

--- a/src/components/LngLatInput.tsx
+++ b/src/components/LngLatInput.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { connect, Dispatch } from 'react-redux'
+
+import {
+    State,
+    Space,
+    ActionType,
+} from '~singletons/interfaces'
+
+interface StateProps {
+    space?: Space
+}
+
+interface DispatchProps {
+    setSpace(longitude: number, latitude: number): void
+}
+
+type Props = StateProps & DispatchProps
+
+const LngLatInput = ({ space, setSpace }: Props): JSX.Element => {
+    if (!space) return <div />
+    return (
+        <div>
+            <label htmlFor='longitude'>Longitude:</label>
+            <input id="longitude" type="number" value={space.longitude} onChange={e => {
+                setSpace(+e.target.value, space.latitude)
+            }} />
+            <label htmlFor='latitude'>Latitude:</label>
+            <input id="latitude" type="number" value={space.latitude} onChange={e => {
+                setSpace(space.longitude, +e.target.value,)
+            }} />
+        </div>
+    )
+}
+
+const mapStateToProps = ({ space }: State): StateProps => ({ space })
+
+const mapDispatchToProps = (dispatch: Dispatch<State>): DispatchProps => ({
+    setSpace: (longitude, latitude) => {
+        dispatch({ type: ActionType.Space, space: { longitude, latitude } })
+    }
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(LngLatInput)

--- a/src/singletons/space.ts
+++ b/src/singletons/space.ts
@@ -13,8 +13,8 @@ export const getSpace = (): Promise<Space> =>
         resolve(space)
       },
       (e: PositionError) => {
-        alert(e.message)
-        reject(e)
+        alert(e.message + ', using default location.')
+        resolve({ longitude: 18.09, latitude: 59.25 })
       },
     )
   })


### PR DESCRIPTION
Hi,
wanted to try this out but it didn't work in my browser even though I accepted the location sharing.

- added fallback location when location lookup fails
- added lng/lat input fields

Marked as draft as it's not styled and lacks any handling of faulty input.

Related to #2 